### PR TITLE
Changes needed to run iRODS container standalone

### DIFF
--- a/irods/Dockerfile
+++ b/irods/Dockerfile
@@ -18,7 +18,7 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -;
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list; \
     apt-get update
 RUN DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y irods-runtime irods-icommands irods-server irods-database-plugin-postgres irods-rule-engine-plugin-audit-amqp irods-rule-engine-plugin-update-collection-mtime irods-rule-engine-plugin-unified-storage-tiering
+    apt-get install -y irods-runtime=4.2.8 irods-icommands=4.2.8 irods-server=4.2.8 irods-database-plugin-postgres=4.2.8 irods-rule-engine-plugin-audit-amqp=4.2.8.0 irods-rule-engine-plugin-update-collection-mtime=4.2.8.0 irods-rule-engine-plugin-unified-storage-tiering=4.2.8.0
 COPY configure_audit_plugin.py /var/lib/irods/scripts/
 COPY configure_update_collection_mtime_plugin.py /var/lib/irods/scripts/
 COPY configure_unified_storage_tiering_plugin.py /var/lib/irods/scripts/

--- a/irods/README.md
+++ b/irods/README.md
@@ -5,5 +5,3 @@ If you want to run just the iRODS image on its own, you need to ensure that dock
 `sudo docker run --name irods -p 1248:1248 -p 1247:1247 --shm-size=512m <imagename>`
 
 If you do not do this, then the process will crash when it is started for the second time, with a shared memory error in the RodsServerLog.
-
-

--- a/irods/README.md
+++ b/irods/README.md
@@ -4,6 +4,6 @@ If you want to run just the iRODS image on its own, you need to ensure that dock
 
 `sudo docker run --name irods -p 1248:1248 -p 1247:1247 --shm-size=512m <imagename>`
 
-If you do not do this, then the process will crash when it is started for the second time, with a shared memory error in the RoseServerLog.
+If you do not do this, then the process will crash when it is started for the second time, with a shared memory error in the RodsServerLog.
 
 

--- a/irods/README.md
+++ b/irods/README.md
@@ -1,0 +1,9 @@
+# Running the image on its own
+
+If you want to run just the iRODS image on its own, you need to ensure that docker gives it enough memory, i.e.;
+
+`sudo docker run --name irods -p 1248:1248 -p 1247:1247 --shm-size=512m <imagename>`
+
+If you do not do this, then the process will crash when it is started for the second time, with a shared memory error in the RoseServerLog.
+
+

--- a/irods/start_provider.sh
+++ b/irods/start_provider.sh
@@ -23,7 +23,10 @@ python configure_update_collection_mtime_plugin.py
 python configure_unified_storage_tiering_plugin.py
 python configure_users.py
 pkill irodsServer
+pkill irodsReServer
 fi
+
+sleep 10 #give it a bit for the procs to finish
 sudo -iu irods bash -c "cd /usr/sbin; ./irodsServer -u"
 
 # Keep container running if the test fails.

--- a/irods/start_provider.sh
+++ b/irods/start_provider.sh
@@ -23,7 +23,6 @@ python configure_update_collection_mtime_plugin.py
 python configure_unified_storage_tiering_plugin.py
 python configure_users.py
 pkill irodsServer
-pkill irodsReServer
 fi
 
 sleep 10 #give it a bit for the procs to finish

--- a/irods/start_provider.sh
+++ b/irods/start_provider.sh
@@ -25,8 +25,22 @@ python configure_users.py
 pkill irodsServer
 fi
 
-sleep 10 #give it a bit for the procs to finish
-sudo -iu irods bash -c "cd /usr/sbin; ./irodsServer -u"
+#give it a bit for the procs to finish
+running="True"
+
+while [ $running = "True" ]
+do
+response=$(echo -e "\x00\x00\x00\x33<MsgHeader_PI><type>HEARTBEAT</type></MsgHeader_PI>" | nc localhost 1247)
+if [ "${response}" == "HEARTBEAT" ]; then
+    running="True"
+    echo "iRODS responding to Heartbeat"
+else
+    running="False"
+    echo "Restarting iRODS"
+    sudo -iu irods bash -c "cd /usr/sbin; ./irodsServer -u"
+fi
+sleep 1
+done
 
 # Keep container running if the test fails.
 #tail -f /dev/null


### PR DESCRIPTION
I ran into a couple of issues when trying to use the irods container on its own,
rather than as part of a compose.

The main issue was that without reserving more shared memory for the docker container, it wouldn't restart.
This can be seen by a boost error in the rodsServerLog when the server was restarted after the `pkill`.

I also found that it can take some time for the processes to finish, otherwise, the restart would fail as the port was still held open.

In addition, since 4.2.9 was released, there is no requirement for the `irods-rule-engine-plugin-update-collection-mtime` package.

Currently, this MR pins the packages to 4.2.8, the last release supported by the package until it was subsumed by 4.2.9