### PR TITLE
iRODS demo with S3 resource plugin and MinIO container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,3 +86,16 @@ services:
             - "/etc/passwd:/etc/passwd:ro"
         depends_on:
             - irods-catalog-provider
+
+    minio:
+        image: minio/minio:RELEASE.2022-10-29T06-21-33Z
+        command: server --address ":19000" --console-address ":19001" /data
+        ports:
+            - "19000:19000"
+            - "19001:19001"
+        volumes:
+          - ./minio-data:/data
+        environment: 
+          MINIO_ROOT_USER: irods
+          MINIO_ROOT_PASSWORD: irodsadmin
+

--- a/irods_catalog_provider/Dockerfile
+++ b/irods_catalog_provider/Dockerfile
@@ -32,12 +32,14 @@ RUN apt-get update && \
 ARG irods_version=4.3.0
 ARG irods_package_version_suffix=-1~focal
 ARG irods_package_version=${irods_version}${irods_package_version_suffix}
+ARG irods_resource_plugin_version=${irods_version}.0${irods_package_version_suffix}
 
 RUN apt-get update && \
     apt-get install -y \
         irods-database-plugin-postgres=${irods_package_version} \
         irods-runtime=${irods_package_version} \
         irods-server=${irods_package_version} \
+        irods-resource-plugin-s3=${irods_resource_plugin_version} \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*

--- a/minio-data/.gitignore
+++ b/minio-data/.gitignore
@@ -1,0 +1,4 @@
+# Ignore MinIO data
+*
+# Don't ignore .gitignore
+!.gitignore


### PR DESCRIPTION
- Add MinIO container with (non-default) ports 19000 and 19001
- Add ./minio-data directory
- Add S3 resource plugin in iRODS catalog provider

The MinIO version is hard-coded. 

Feel free to modify or create own pull request (then I will close this one) - I figure maybe you'd like to change port numbers, make the MinIO version a parameter, etc..