### PR TITLE
[40] add s3 plugin configuration and default demobucket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
         restart: always
         depends_on:
             - irods-catalog
+            - minio
 
     irods-catalog-consumer:
         build:
@@ -134,14 +135,15 @@ services:
                 condition: service_healthy
 
     minio:
-        image: minio/minio:RELEASE.2022-10-29T06-21-33Z
-        command: server --address ":19000" --console-address ":19001" /data
+        image: minio/minio:RELEASE.2024-09-13T20-26-02Z
         ports:
             - "19000:19000"
             - "19001:19001"
         volumes:
           - ./minio-data:/data
+        command: minio server /data
         environment: 
           MINIO_ROOT_USER: irods
           MINIO_ROOT_PASSWORD: irodsadmin
-
+          MINIO_ADDRESS: ":19000"
+          MINIO_CONSOLE_ADDRESS: ":19001"

--- a/irods_catalog_provider/Dockerfile
+++ b/irods_catalog_provider/Dockerfile
@@ -46,8 +46,10 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 COPY unattended_install.json /
+COPY s3.keypair /var/lib/irods/
 
 WORKDIR /
+COPY firstrun.sh .
 COPY entrypoint.sh .
 RUN chmod u+x ./entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]

--- a/irods_catalog_provider/entrypoint.sh
+++ b/irods_catalog_provider/entrypoint.sh
@@ -17,6 +17,9 @@ if [ -e "${unattended_install_file}" ]; then
     sed -i "s/THE_HOSTNAME/${HOSTNAME}/g" ${unattended_install_file}
     python3 /var/lib/irods/scripts/setup_irods.py --json_configuration_file ${unattended_install_file}
     rm ${unattended_install_file}
+
+    echo "Running firstrun.sh"
+    bash firstrun.sh
 fi
 
 echo "Starting server"

--- a/irods_catalog_provider/firstrun.sh
+++ b/irods_catalog_provider/firstrun.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+su - irods -c '/var/lib/irods/irodsctl start'
+
+# create s3 resource
+su - irods -c 'iadmin mkresc s3resc s3 irods-catalog-provider:/demobucket/thevault "S3_DEFAULT_HOSTNAME=minio:19000;S3_AUTH_FILE=/var/lib/irods/s3.keypair;S3_REGIONNAME=us-east-1;S3_RETRY_COUNT=1;S3_WAIT_TIME_SECONDS=3;S3_PROTO=HTTP;ARCHIVE_NAMING_POLICY=consistent;HOST_MODE=cacheless_attached"'
+
+su - irods -c '/var/lib/irods/irodsctl stop'

--- a/irods_catalog_provider/s3.keypair
+++ b/irods_catalog_provider/s3.keypair
@@ -1,0 +1,2 @@
+irods
+irodsadmin

--- a/irods_catalog_provider/unattended_install.json
+++ b/irods_catalog_provider/unattended_install.json
@@ -75,7 +75,12 @@
             "access_entries": []
         },
         "host_resolution": {
-            "host_entries": []
+            "host_entries": [
+            {
+                "address_type": "local",
+                "addresses": ["irods-catalog-provider", "THE_HOSTNAME"]
+            }
+            ]
         },
         "log_level": {
             "agent": "info",

--- a/minio-data/.gitignore
+++ b/minio-data/.gitignore
@@ -2,3 +2,5 @@
 *
 # Don't ignore .gitignore
 !.gitignore
+# Don't ignore default demobucket
+!demobucket

--- a/minio-data/demobucket/.gitignore
+++ b/minio-data/demobucket/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
`docker compose up` will now have `s3resc` configured and ready to receive files.

also updated the minio version to latest.

the client container is being used to run the `iadmin mkresc` command... open to better solutions.