### PR TITLE
[88] update to HTTP API v0.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
                 condition: service_healthy
 
     irods-client-http-api:
-        image: irods/irods_http_api:0.4.0
+        image: irods/irods_http_api:0.5.0
         volumes:
             - ./irods_client_http_api/config.json:/config.json:ro
         ports:


### PR DESCRIPTION
curl verified it was working...

```
$ curl -vvv localhost:9001
*   Trying ::1:9001...                                                             
* TCP_NODELAY set                                                                  
* Connected to localhost (::1) port 9001 (#0)
> GET / HTTP/1.1                                                                   
> Host: localhost:9001                                                                                                                                                
> User-Agent: curl/7.68.0                                                          
> Accept: */*                                                                      
>                                                                                  
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found                                                           
< Server: irods_http_api/0.5.0 (d63e2aa2ae655457176c13260b6edfe90742ef61)
< Content-Type: application/json
< Content-Length: 0                  
<                                                                                  
* Connection #0 to host localhost left intact                          
```